### PR TITLE
ci: skip workflow runs on bot PRs

### DIFF
--- a/.github/workflows/license_check.yaml
+++ b/.github/workflows/license_check.yaml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   build:
+    if: ${{ !contains(fromJSON('["dependabot[bot]", "renovate[bot]", "snyk-bot", "allcontributors[bot]"]'), github.actor) }}
     defaults:
       run:
         working-directory: .

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   semantic-pull-request:
+    if: ${{ !contains(fromJSON('["dependabot[bot]", "renovate[bot]", "snyk-bot", "allcontributors[bot]"]'), github.actor) }}
     runs-on: ubuntu-latest
 
     steps:
@@ -30,6 +31,7 @@ jobs:
           wip: false
 
   build:
+    if: ${{ !contains(fromJSON('["dependabot[bot]", "renovate[bot]", "snyk-bot", "allcontributors[bot]"]'), github.actor) }}
     defaults:
       run:
         working-directory: .
@@ -79,6 +81,7 @@ jobs:
           verbose: true
 
   spell-check:
+    if: ${{ !contains(fromJSON('["dependabot[bot]", "renovate[bot]", "snyk-bot", "allcontributors[bot]"]'), github.actor) }}
     defaults:
       run:
         working-directory: .


### PR DESCRIPTION
Adds an `if` condition to every job so that dependency-bot PRs (dependabot, renovate, etc.) do not trigger Actions runs, reducing unnecessary minutes usage.