### PR TITLE
fix: bump bloc from 9.2.0 to 9.2.1

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: "direct main"
     description:
       name: bloc
-      sha256: a48653a82055a900b88cd35f92429f068c5a8057ae9b136d197b3d56c57efb81
+      sha256: e03b235924e4f509c27b5d6b2f949200e0a91149a9818b4f65eeb56662b75413
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.0"
+    version: "9.2.1"
   bloc_test:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   auto_size_text: ^3.0.0
-  bloc: ^9.2.0
+  bloc: ^9.2.1
   connectivity_plus: ^7.1.1
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
Resolves Dependabot alert (PR #71). This patch release fixes `isClosed`
incorporating event controller state.

https://claude.ai/code/session_01Y6hd63gFWqPHL5TLdxHSSo