### PR TITLE
feat(calculator): widen the zero key to match the iPhone keypad

### DIFF
--- a/lib/presentation/enums/button_type.dart
+++ b/lib/presentation/enums/button_type.dart
@@ -25,10 +25,7 @@ enum ButtonType {
   zero('0'),
 
   // 소수점
-  dot('.'),
-
-  // 아무 역할 없는 버튼. 나중에 공학계산기 기능 추가 시 사용.
-  calculator('');
+  dot('.');
 
   const ButtonType(this.text);
   final String text;

--- a/lib/presentation/pages/calculator_screen.dart
+++ b/lib/presentation/pages/calculator_screen.dart
@@ -118,157 +118,136 @@ class CalculatorView extends StatelessWidget {
                     ],
                   ),
                 ),
-                // 버튼 영역
+                // 버튼 영역: iPhone처럼 4열 그리드에 '0'이 두 칸을 차지하도록
+                // unit 크기를 계산해 배치한다.
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                  child: Column(
-                    children: [
-                      Row(
-                        spacing: 12,
-                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  child: LayoutBuilder(
+                    builder: (BuildContext context, BoxConstraints constraints) {
+                      const gap = 12.0;
+                      const digitColor = Color(0xFF2B2B2D);
+                      const functionColor = Color(0xFF5C5C60);
+                      const operatorColor = Color(0xFFFFA00A);
+                      // 4열 + 3 간격을 제외한 폭을 4등분한 것이 버튼 한 칸(unit)이다.
+                      final unit = (constraints.maxWidth - gap * 3) / 4;
+
+                      SizedBox cell(Widget child, {bool wide = false}) {
+                        return SizedBox(
+                          width: wide ? unit * 2 + gap : unit,
+                          height: unit,
+                          child: child,
+                        );
+                      }
+
+                      CalculatorButton digit(ButtonType type) {
+                        return CalculatorButton(
+                          button: type,
+                          buttonColor: digitColor,
+                          buttonPressed: (String val) => bloc.add(CalculatorEvent.input(val)),
+                        );
+                      }
+
+                      CalculatorButton operatorButton(ButtonType type) {
+                        return CalculatorButton(
+                          button: type,
+                          buttonColor: operatorColor,
+                          isSelected: pendingOperator == type.text,
+                          buttonPressed: (String val) => bloc.add(CalculatorEvent.input(val)),
+                        );
+                      }
+
+                      return Column(
                         children: [
-                          CalculatorButton(
-                            button: state.result != '0' ? ButtonType.clear : ButtonType.delete,
-                            buttonColor: const Color(0xFF5C5C60),
-                            buttonPressed: (String val) {
-                              if (val == 'AC') {
-                                bloc.add(const CalculatorEvent.clear());
-                              } else {
-                                bloc.add(const CalculatorEvent.delete());
-                              }
-                            },
+                          Row(
+                            spacing: gap,
+                            children: [
+                              cell(
+                                CalculatorButton(
+                                  button: state.result != '0' ? ButtonType.clear : ButtonType.delete,
+                                  buttonColor: functionColor,
+                                  buttonPressed: (String val) {
+                                    if (val == 'AC') {
+                                      bloc.add(const CalculatorEvent.clear());
+                                    } else {
+                                      bloc.add(const CalculatorEvent.delete());
+                                    }
+                                  },
+                                ),
+                              ),
+                              cell(
+                                CalculatorButton(
+                                  button: ButtonType.plusMinus,
+                                  buttonColor: functionColor,
+                                  buttonPressed: (_) => bloc.add(const CalculatorEvent.flipSign()),
+                                ),
+                              ),
+                              cell(
+                                CalculatorButton(
+                                  button: ButtonType.percent,
+                                  buttonColor: functionColor,
+                                  buttonPressed: (String val) => bloc.add(CalculatorEvent.input(val)),
+                                ),
+                              ),
+                              cell(operatorButton(ButtonType.division)),
+                            ],
                           ),
-                          CalculatorButton(
-                            button: ButtonType.plusMinus,
-                            buttonColor: const Color(0xFF5C5C60),
-                            buttonPressed: (_) => bloc.add(const CalculatorEvent.flipSign()),
+                          const SizedBox(height: gap),
+                          Row(
+                            spacing: gap,
+                            children: [
+                              cell(digit(ButtonType.seven)),
+                              cell(digit(ButtonType.eight)),
+                              cell(digit(ButtonType.nine)),
+                              cell(operatorButton(ButtonType.multiple)),
+                            ],
                           ),
-                          CalculatorButton(
-                            button: ButtonType.percent,
-                            buttonColor: const Color(0xFF5C5C60),
-                            buttonPressed: (String val) => bloc.add(CalculatorEvent.input(val)),
+                          const SizedBox(height: gap),
+                          Row(
+                            spacing: gap,
+                            children: [
+                              cell(digit(ButtonType.four)),
+                              cell(digit(ButtonType.five)),
+                              cell(digit(ButtonType.six)),
+                              cell(operatorButton(ButtonType.minus)),
+                            ],
                           ),
-                          CalculatorButton(
-                            button: ButtonType.division,
-                            buttonColor: const Color(0xFFFFA00A),
-                            isSelected: pendingOperator == ButtonType.division.text,
-                            buttonPressed: (String val) => bloc.add(CalculatorEvent.input(val)),
+                          const SizedBox(height: gap),
+                          Row(
+                            spacing: gap,
+                            children: [
+                              cell(digit(ButtonType.one)),
+                              cell(digit(ButtonType.two)),
+                              cell(digit(ButtonType.three)),
+                              cell(operatorButton(ButtonType.plus)),
+                            ],
                           ),
+                          const SizedBox(height: gap),
+                          Row(
+                            spacing: gap,
+                            children: [
+                              cell(
+                                CalculatorButton(
+                                  button: ButtonType.zero,
+                                  buttonColor: digitColor,
+                                  wide: true,
+                                  buttonPressed: (String val) => bloc.add(CalculatorEvent.input(val)),
+                                ),
+                                wide: true,
+                              ),
+                              cell(digit(ButtonType.dot)),
+                              cell(
+                                CalculatorButton(
+                                  button: ButtonType.result,
+                                  buttonColor: operatorColor,
+                                  buttonPressed: (_) => bloc.add(const CalculatorEvent.evaluate()),
+                                ),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 24),
                         ],
-                      ),
-                      const SizedBox(height: 12),
-                      Row(
-                        spacing: 12,
-                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                        children: [
-                          CalculatorButton(
-                            button: ButtonType.seven,
-                            buttonColor: const Color(0xFF2B2B2D),
-                            buttonPressed: (String val) => bloc.add(CalculatorEvent.input(val)),
-                          ),
-                          CalculatorButton(
-                            button: ButtonType.eight,
-                            buttonColor: const Color(0xFF2B2B2D),
-                            buttonPressed: (String val) => bloc.add(CalculatorEvent.input(val)),
-                          ),
-                          CalculatorButton(
-                            button: ButtonType.nine,
-                            buttonColor: const Color(0xFF2B2B2D),
-                            buttonPressed: (String val) => bloc.add(CalculatorEvent.input(val)),
-                          ),
-                          CalculatorButton(
-                            button: ButtonType.multiple,
-                            buttonColor: const Color(0xFFFFA00A),
-                            isSelected: pendingOperator == ButtonType.multiple.text,
-                            buttonPressed: (String val) => bloc.add(CalculatorEvent.input(val)),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 12),
-                      Row(
-                        spacing: 12,
-                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                        children: [
-                          CalculatorButton(
-                            button: ButtonType.four,
-                            buttonColor: const Color(0xFF2B2B2D),
-                            buttonPressed: (String val) => bloc.add(CalculatorEvent.input(val)),
-                          ),
-                          CalculatorButton(
-                            button: ButtonType.five,
-                            buttonColor: const Color(0xFF2B2B2D),
-                            buttonPressed: (String val) => bloc.add(CalculatorEvent.input(val)),
-                          ),
-                          CalculatorButton(
-                            button: ButtonType.six,
-                            buttonColor: const Color(0xFF2B2B2D),
-                            buttonPressed: (String val) => bloc.add(CalculatorEvent.input(val)),
-                          ),
-                          CalculatorButton(
-                            button: ButtonType.minus,
-                            buttonColor: const Color(0xFFFFA00A),
-                            isSelected: pendingOperator == ButtonType.minus.text,
-                            buttonPressed: (String val) => bloc.add(CalculatorEvent.input(val)),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 12),
-                      Row(
-                        spacing: 12,
-                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                        children: [
-                          CalculatorButton(
-                            button: ButtonType.one,
-                            buttonColor: const Color(0xFF2B2B2D),
-                            buttonPressed: (String val) => bloc.add(CalculatorEvent.input(val)),
-                          ),
-                          CalculatorButton(
-                            button: ButtonType.two,
-                            buttonColor: const Color(0xFF2B2B2D),
-                            buttonPressed: (String val) => bloc.add(CalculatorEvent.input(val)),
-                          ),
-                          CalculatorButton(
-                            button: ButtonType.three,
-                            buttonColor: const Color(0xFF2B2B2D),
-                            buttonPressed: (String val) => bloc.add(CalculatorEvent.input(val)),
-                          ),
-                          CalculatorButton(
-                            button: ButtonType.plus,
-                            buttonColor: const Color(0xFFFFA00A),
-                            isSelected: pendingOperator == ButtonType.plus.text,
-                            buttonPressed: (String val) => bloc.add(CalculatorEvent.input(val)),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 12),
-                      Row(
-                        spacing: 12,
-                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                        children: [
-                          CalculatorButton(
-                            button: ButtonType.calculator,
-                            buttonColor: const Color(0xFF2B2B2D),
-                            buttonPressed: (String val) {},
-                          ),
-                          CalculatorButton(
-                            button: ButtonType.zero,
-                            buttonColor: const Color(0xFF2B2B2D),
-                            buttonPressed: (String val) => bloc.add(CalculatorEvent.input(val)),
-                          ),
-                          CalculatorButton(
-                            button: ButtonType.dot,
-                            buttonColor: const Color(0xFF2B2B2D),
-                            buttonPressed: (String val) => bloc.add(CalculatorEvent.input(val)),
-                          ),
-                          CalculatorButton(
-                            button: ButtonType.result,
-                            buttonColor: const Color(0xFFFFA00A),
-                            buttonPressed: (_) => bloc.add(const CalculatorEvent.evaluate()),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 24),
-                    ],
+                      );
+                    },
                   ),
                 ),
               ],

--- a/lib/presentation/widgets/calculator_button.dart
+++ b/lib/presentation/widgets/calculator_button.dart
@@ -13,6 +13,7 @@ class CalculatorButton extends StatelessWidget {
     required this.buttonColor,
     required this.buttonPressed,
     this.isSelected = false,
+    this.wide = false,
   });
 
   final ButtonType button;
@@ -22,53 +23,46 @@ class CalculatorButton extends StatelessWidget {
   /// iPhone처럼 대기 중인 연산자를 강조한다(흰 배경 + 연산자색 글리프).
   final bool isSelected;
 
+  /// iPhone의 넓은 '0' 키처럼 두 칸을 차지하는 알약형 버튼으로 렌더링한다.
+  final bool wide;
+
   @override
   Widget build(BuildContext context) {
     // 선택된 연산자는 배경/전경 색을 반전한다.
     final backgroundColor = isSelected ? Colors.white : buttonColor;
     final foregroundColor = isSelected ? buttonColor : Colors.white;
 
-    return Expanded(
-      child: AspectRatio(
-        aspectRatio: 1,
-        child: ElevatedButton(
-          onPressed: () {
-            buttonPressed(button.text);
-          },
-          style: ElevatedButton.styleFrom(
-            shape: const CircleBorder(),
-            maximumSize: const Size.square(90),
-            minimumSize: const Size.square(80),
-            backgroundColor: backgroundColor,
-            disabledBackgroundColor: backgroundColor,
-            elevation: 0,
-            padding: EdgeInsets.zero,
-          ),
-          child: switch (button) {
-            .delete => Assets.svgs.delete.svg(
-              colorFilter: ColorFilter.mode(foregroundColor, BlendMode.srcIn),
-              semanticsLabel: button.name,
-              width: 40,
-              height: 40,
-            ),
-            .calculator => Assets.svgs.calculator.svg(
-              colorFilter: ColorFilter.mode(foregroundColor, BlendMode.srcIn),
-              semanticsLabel: button.name,
-              width: 40,
-              height: 40,
-            ),
-            _ => Text(
-              button.text,
-              style: TextStyle(
-                color: foregroundColor,
-                fontFamily: FontFamily.sFProDisplay,
-                fontSize: button.text.length > 1 ? 23 : 36,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-          },
-        ),
+    // 부모(SizedBox)가 정한 크기를 채운다. 넓은 버튼은 알약형(StadiumBorder).
+    return ElevatedButton(
+      onPressed: () {
+        buttonPressed(button.text);
+      },
+      style: ElevatedButton.styleFrom(
+        shape: wide ? const StadiumBorder() : const CircleBorder(),
+        minimumSize: Size.zero,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        backgroundColor: backgroundColor,
+        disabledBackgroundColor: backgroundColor,
+        elevation: 0,
+        padding: EdgeInsets.zero,
       ),
+      child: switch (button) {
+        .delete => Assets.svgs.delete.svg(
+          colorFilter: ColorFilter.mode(foregroundColor, BlendMode.srcIn),
+          semanticsLabel: button.name,
+          width: 40,
+          height: 40,
+        ),
+        _ => Text(
+          button.text,
+          style: TextStyle(
+            color: foregroundColor,
+            fontFamily: FontFamily.sFProDisplay,
+            fontSize: button.text.length > 1 ? 23 : 36,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      },
     );
   }
 }

--- a/test/presentation/pages/calculator_screen_test.dart
+++ b/test/presentation/pages/calculator_screen_test.dart
@@ -113,9 +113,6 @@ void main() {
     // FlipSign(+/-) 버튼 누름
     await tester.tapButton(ButtonType.plusMinus);
 
-    // empty 버튼 누름 (아무 기능도 하지 않음)
-    await tester.tapButton(ButtonType.calculator);
-
     // 음수로 바뀌었는지 확인
     expect(find.text('-7'), findsWidgets);
 

--- a/test/presentation/widgets/calculator_button_test.dart
+++ b/test/presentation/widgets/calculator_button_test.dart
@@ -117,7 +117,7 @@ void main() {
       expect(backgroundColor, equals(testColor));
     });
 
-    testWidgets('maintains aspect ratio of 1:1', (WidgetTester tester) async {
+    testWidgets('uses a circle shape by default', (WidgetTester tester) async {
       await tester.pumpApp(
         Scaffold(
           body: Column(
@@ -132,8 +132,28 @@ void main() {
         ),
       );
 
-      final aspectRatio = tester.widget<AspectRatio>(find.byType(AspectRatio));
-      expect(aspectRatio.aspectRatio, equals(1.0));
+      final button = tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+      expect(button.style?.shape?.resolve({}), isA<CircleBorder>());
+    });
+
+    testWidgets('uses a stadium shape when wide', (WidgetTester tester) async {
+      await tester.pumpApp(
+        Scaffold(
+          body: Column(
+            children: [
+              CalculatorButton(
+                button: ButtonType.zero,
+                buttonColor: Colors.grey,
+                buttonPressed: onPressed,
+                wide: true,
+              ),
+            ],
+          ),
+        ),
+      );
+
+      final button = tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+      expect(button.style?.shape?.resolve({}), isA<StadiumBorder>());
     });
   });
 }


### PR DESCRIPTION
## Description

Stacked on #78. Restores the iconic iPhone keypad layout: the `0` key spans two columns and the dead scientific placeholder is gone.

The old layout sized each button with `Expanded` + `AspectRatio(1)` and relied on `spacing`, which cannot keep the columns aligned once one key spans two cells. This switches the keypad to a `LayoutBuilder` unit grid: it computes a single cell size from the available width and places each key in a fixed `SizedBox`, so the wide `0` lines up exactly with the columns above it.

Changes:

- **Wide `0` key** — spans two columns as a stadium (pill) shape; the `.` and `=` keys keep their columns.
- **Removed the placeholder** — `ButtonType.calculator` (the non-functional 🧮 key reserved for a scientific mode) is deleted, and the freed slot goes back to the `0` key.
- **Button sizing** — `CalculatorButton` now fills the size its parent gives it instead of self-sizing, and gains a `wide` flag for the stadium shape.

## Verification

- `flutter analyze` — no issues
- `flutter test` — 150/150 passing (replaced the aspect-ratio test with circle/stadium shape tests)
- Ran on the iPhone 17e simulator: the `0` key is a wide pill spanning two columns, the placeholder is gone, and every column stays aligned.

## Note

The `0` glyph is centered in the wide key; the iPhone left-aligns it over the first column. Left is a small follow-up polish if we want an exact match.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Test
