### PR TITLE
feat(calculator): evaluate unary percent (fix UnsupportedError)

### DIFF
--- a/lib/data/repositories/calculate_repository_impl.dart
+++ b/lib/data/repositories/calculate_repository_impl.dart
@@ -48,11 +48,12 @@ class CalculatorRepositoryImpl implements CalculatorRepository {
 
   /// 단항 퍼센트를 리터럴 분수로 변환한다.
   ///
-  /// 예: `50%` → `0.5`, `89%*98%` → `0.89*0.98`.
-  /// 로컬 datasource가 괄호를 지원하지 않으므로 값 자체로 치환한다.
+  /// 예: `50%` → `0.5`, `89%*98%` → `0.89*0.98`, `.5%` → `0.005`.
+  /// 숫자 패턴은 선행 0이 없는 소수(`.5`)까지 포함한다. 로컬 datasource가
+  /// 괄호를 지원하지 않으므로 값 자체로 치환한다.
   String _normalizePercent(String expression) {
     return expression.replaceAllMapped(
-      RegExp(r'(\d+\.?\d*)%'),
+      RegExp(r'(\d+\.?\d*|\.\d+)%'),
       (Match match) => '${double.parse(match.group(1)!) / 100}',
     );
   }

--- a/lib/data/repositories/calculate_repository_impl.dart
+++ b/lib/data/repositories/calculate_repository_impl.dart
@@ -22,6 +22,10 @@ class CalculatorRepositoryImpl implements CalculatorRepository {
 
   @override
   Future<double> calculate(String expression) async {
+    // iPhone식 단항 퍼센트("50%" → "0.5")로 정규화한다. 로컬/원격 datasource가
+    // 모두 처리할 수 있도록 괄호 없이 리터럴 값으로 치환한다.
+    final normalized = _normalizePercent(expression);
+
     final result = await connectivity.checkConnectivity();
     final connected = result.any((ConnectivityResult con) => con != ConnectivityResult.none);
 
@@ -30,15 +34,26 @@ class CalculatorRepositoryImpl implements CalculatorRepository {
 
     if (!connected) {
       // Offline status: Use local data source
-      return localDatasource.calculate(expression);
+      return localDatasource.calculate(normalized);
     } else {
       try {
         // Online status: Use remote data source
-        return remoteDatasource.calculate(expression);
+        return remoteDatasource.calculate(normalized);
       } catch (e) {
         // Use local data source when remote call fails
-        return localDatasource.calculate(expression);
+        return localDatasource.calculate(normalized);
       }
     }
+  }
+
+  /// 단항 퍼센트를 리터럴 분수로 변환한다.
+  ///
+  /// 예: `50%` → `0.5`, `89%*98%` → `0.89*0.98`.
+  /// 로컬 datasource가 괄호를 지원하지 않으므로 값 자체로 치환한다.
+  String _normalizePercent(String expression) {
+    return expression.replaceAllMapped(
+      RegExp(r'(\d+\.?\d*)%'),
+      (Match match) => '${double.parse(match.group(1)!) / 100}',
+    );
   }
 }

--- a/lib/presentation/bloc/calculator_bloc.dart
+++ b/lib/presentation/bloc/calculator_bloc.dart
@@ -80,7 +80,7 @@ class CalculatorBloc extends Bloc<CalculatorEvent, CalculatorState> {
   }
 
   Future<void> _onEvaluate(Evaluate event, Emitter<CalculatorState> emit) async {
-    final expression = state.equation.replaceAll('×', '*').replaceAll('÷', '/').replaceAll('%', '%');
+    final expression = state.equation.replaceAll('×', '*').replaceAll('÷', '/');
 
     try {
       var result = '${await _repository.calculate(expression)}';

--- a/test/data/repositories/calculate_repository_impl_test.dart
+++ b/test/data/repositories/calculate_repository_impl_test.dart
@@ -109,5 +109,7 @@ void main() {
 
     expect(await realRepository.calculate('50%'), equals(0.5));
     expect(await realRepository.calculate('200*10%'), equals(20.0));
+    // 선행 0이 없는 소수 퍼센트(예: '.' '5' '%')도 처리한다.
+    expect(await realRepository.calculate('.5%'), equals(0.005));
   });
 }

--- a/test/data/repositories/calculate_repository_impl_test.dart
+++ b/test/data/repositories/calculate_repository_impl_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 
 // 🌎 Project imports:
+import 'package:calculator/data/datasources/calculator_local_datasource.dart';
 import 'package:calculator/data/repositories/calculate_repository_impl.dart';
 import '../../calculator_test.mocks.dart';
 
@@ -86,5 +87,27 @@ void main() {
     expect(actual, equals(result));
     verify(mockRemoteDatasource.calculate(expression));
     verifyNever(mockLocalDatasource.calculate(expression));
+  });
+
+  test('normalizes unary percent before delegating to a datasource', () async {
+    when(mockConnectivity.checkConnectivity()).thenAnswer((_) async => [ConnectivityResult.none]);
+    when(mockLocalDatasource.calculate('0.5')).thenAnswer((_) => 0.5);
+
+    final actual = await repository.calculate('50%');
+
+    expect(actual, equals(0.5));
+    verify(mockLocalDatasource.calculate('0.5'));
+  });
+
+  test('evaluates percent end to end through the real local datasource', () async {
+    final realRepository = CalculatorRepositoryImpl(
+      localDatasource: CalculatorLocalDatasource(),
+      remoteDatasource: mockRemoteDatasource,
+      connectivity: mockConnectivity,
+    );
+    when(mockConnectivity.checkConnectivity()).thenAnswer((_) async => [ConnectivityResult.none]);
+
+    expect(await realRepository.calculate('50%'), equals(0.5));
+    expect(await realRepository.calculate('200*10%'), equals(20.0));
   });
 }


### PR DESCRIPTION
## Description

Makes the `%` key actually compute instead of erroring. Before this, `%` reached the offline datasource unchanged and threw `UnsupportedError` (visible as `UnsupportedError` on screen for inputs like `89%×98%`).

`%` is normalized in `CalculatorRepositoryImpl`, just before it routes to a datasource. It converts a trailing percent to its literal fraction — `50%` → `0.5`, `89%*98%` → `0.89*0.98` — so both the online (`math_expressions`) and offline (custom tokenizer) paths evaluate it. The value form is used instead of `(N/100)` because the offline tokenizer does not support parentheses.

Doing it in the repository keeps the datasources' own unit tests meaningful (the local datasource still rejects `%` as a raw operator) and leaves the bloc's pass-through contract intact.

Also removes a no-op `replaceAll('%', '%')` in the bloc.

## Verification

- `flutter analyze` — no issues
- `flutter test` — 152/152 passing, including a new end-to-end test that evaluates `50%` → `0.5` and `200*10%` → `20.0` through the real local datasource.

## Note

This implements unary percent (`N%` = `N / 100`). The iPhone's contextual percent (`200 + 10%` = `220`) is not covered; that is a larger change and can be a follow-up if we want an exact match.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [x] 🧪 Test
