### PR TITLE
fix(calculator): show AC on the empty screen instead of backspace

### DIFF
--- a/lib/presentation/pages/calculator_screen.dart
+++ b/lib/presentation/pages/calculator_screen.dart
@@ -163,7 +163,10 @@ class CalculatorView extends StatelessWidget {
                             children: [
                               cell(
                                 CalculatorButton(
-                                  button: state.result != '0' ? ButtonType.clear : ButtonType.delete,
+                                  // 빈 화면이거나 결과가 있으면 AC(전체 지움), 식을 입력 중이면 ⌫(백스페이스).
+                                  button: (state.result != '0' || state.equation == '0')
+                                      ? ButtonType.clear
+                                      : ButtonType.delete,
                                   buttonColor: functionColor,
                                   buttonPressed: (String val) {
                                     if (val == 'AC') {

--- a/test/presentation/pages/calculator_screen_test.dart
+++ b/test/presentation/pages/calculator_screen_test.dart
@@ -93,6 +93,31 @@ void main() {
     expect(find.text('0'), findsWidgets); // 초기화 후 결과가 0인지 체크
   });
 
+  testWidgets('shows AC (not backspace) on the initial empty screen', (WidgetTester tester) async {
+    await tester.pumpApp(
+      BlocProvider<CalculatorBloc>(
+        create: (context) => CalculatorBloc(
+          repository: CalculatorRepositoryImpl(
+            localDatasource: mockLocalDatasource,
+            remoteDatasource: mockRemoteDatasource,
+            connectivity: mockConnectivity,
+          ),
+        ),
+        child: const CalculatorView(),
+      ),
+    );
+
+    final clearFinder = find.byWidgetPredicate(
+      (widget) => widget is CalculatorButton && widget.button == ButtonType.clear,
+    );
+    final deleteFinder = find.byWidgetPredicate(
+      (widget) => widget is CalculatorButton && widget.button == ButtonType.delete,
+    );
+
+    expect(clearFinder, findsOneWidget);
+    expect(deleteFinder, findsNothing);
+  });
+
   testWidgets('CalculatorScreen buttonPressed for delete and flipSign', (WidgetTester tester) async {
     await tester.pumpApp(
       BlocProvider<CalculatorBloc>(


### PR DESCRIPTION
## Description

Fixes the clear key so a fresh screen shows `AC`, matching the iPhone.

The label was keyed on `result`, so on an empty screen (`result == '0'`) it showed the ⌫ backspace glyph — confusing, and there is nothing to delete. It now shows `AC` when the screen is empty (`equation == '0'`) or a result exists, and keeps ⌫ only while an expression is being entered.

We deliberately keep the backspace (⌫) during entry rather than switching to the iPhone's `C`; it is a useful capability the iPhone lacks, and clearing to `AC` after `=` still gives a one-tap clear-all. No bloc/model changes.

## Verification

- `flutter analyze` — no issues
- `flutter test` — 153/153 passing (added a regression test: the initial screen shows `AC`, not backspace)
- iPhone 17e simulator: the fresh screen now shows `AC`.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [x] 🧪 Test
