### PR TITLE
feat(calculator): left-align the wide zero glyph to match iPhone

### DIFF
--- a/lib/presentation/pages/calculator_screen.dart
+++ b/lib/presentation/pages/calculator_screen.dart
@@ -233,6 +233,8 @@ class CalculatorView extends StatelessWidget {
                                   button: ButtonType.zero,
                                   buttonColor: digitColor,
                                   wide: true,
+                                  // iPhone처럼 '0' 글리프를 첫 칸 중앙(위 숫자 열과 정렬)에 둔다.
+                                  contentPadding: EdgeInsets.only(right: unit + gap),
                                   buttonPressed: (String val) => bloc.add(CalculatorEvent.input(val)),
                                 ),
                                 wide: true,

--- a/lib/presentation/widgets/calculator_button.dart
+++ b/lib/presentation/widgets/calculator_button.dart
@@ -14,6 +14,7 @@ class CalculatorButton extends StatelessWidget {
     required this.buttonPressed,
     this.isSelected = false,
     this.wide = false,
+    this.contentPadding = EdgeInsets.zero,
   });
 
   final ButtonType button;
@@ -25,6 +26,9 @@ class CalculatorButton extends StatelessWidget {
 
   /// iPhone의 넓은 '0' 키처럼 두 칸을 차지하는 알약형 버튼으로 렌더링한다.
   final bool wide;
+
+  /// 자식(글리프) 주변 패딩. 넓은 '0' 키의 글리프를 첫 칸 위로 좌측 정렬할 때 사용한다.
+  final EdgeInsetsGeometry contentPadding;
 
   @override
   Widget build(BuildContext context) {
@@ -44,7 +48,7 @@ class CalculatorButton extends StatelessWidget {
         backgroundColor: backgroundColor,
         disabledBackgroundColor: backgroundColor,
         elevation: 0,
-        padding: EdgeInsets.zero,
+        padding: contentPadding,
       ),
       child: switch (button) {
         .delete => Assets.svgs.delete.svg(


### PR DESCRIPTION
## Description

Follow-up polish from #79. The `0` key spans two columns, but its glyph was centered in the pill. It now sits over the first column, aligned with the `1` / `4` / `7` keys above it, matching the iPhone.

`CalculatorButton` gains a `contentPadding`; the wide `0` passes `EdgeInsets.only(right: unit + gap)` so the centered glyph shifts to the first column's center. The pill itself still spans both columns.

## Verification

- `flutter analyze` — no issues
- `flutter test` — 153/153 passing
- iPhone 17e simulator: the `0` glyph lines up with the digit column above it.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Test
