### PR TITLE
feat(calculator): match the iOS key color palette

### DIFF
--- a/lib/presentation/pages/calculator_screen.dart
+++ b/lib/presentation/pages/calculator_screen.dart
@@ -125,9 +125,12 @@ class CalculatorView extends StatelessWidget {
                   child: LayoutBuilder(
                     builder: (BuildContext context, BoxConstraints constraints) {
                       const gap = 12.0;
-                      const digitColor = Color(0xFF2B2B2D);
-                      const functionColor = Color(0xFF5C5C60);
-                      const operatorColor = Color(0xFFFFA00A);
+                      // iOS 계산기 팔레트에 맞춘 색상.
+                      const digitColor = Color(0xFF333333);
+                      const functionColor = Color(0xFFA5A5A5);
+                      const operatorColor = Color(0xFFFF9F0A);
+                      // iOS 함수 키(AC/±/%)는 밝은 회색 배경에 검정 글리프를 쓴다.
+                      const functionForeground = Colors.black;
                       // 4열 + 3 간격을 제외한 폭을 4등분한 것이 버튼 한 칸(unit)이다.
                       final unit = (constraints.maxWidth - gap * 3) / 4;
 
@@ -168,6 +171,7 @@ class CalculatorView extends StatelessWidget {
                                       ? ButtonType.clear
                                       : ButtonType.delete,
                                   buttonColor: functionColor,
+                                  foregroundColor: functionForeground,
                                   buttonPressed: (String val) {
                                     if (val == 'AC') {
                                       bloc.add(const CalculatorEvent.clear());
@@ -181,6 +185,7 @@ class CalculatorView extends StatelessWidget {
                                 CalculatorButton(
                                   button: ButtonType.plusMinus,
                                   buttonColor: functionColor,
+                                  foregroundColor: functionForeground,
                                   buttonPressed: (_) => bloc.add(const CalculatorEvent.flipSign()),
                                 ),
                               ),
@@ -188,6 +193,7 @@ class CalculatorView extends StatelessWidget {
                                 CalculatorButton(
                                   button: ButtonType.percent,
                                   buttonColor: functionColor,
+                                  foregroundColor: functionForeground,
                                   buttonPressed: (String val) => bloc.add(CalculatorEvent.input(val)),
                                 ),
                               ),

--- a/lib/presentation/widgets/calculator_button.dart
+++ b/lib/presentation/widgets/calculator_button.dart
@@ -15,6 +15,7 @@ class CalculatorButton extends StatelessWidget {
     this.isSelected = false,
     this.wide = false,
     this.contentPadding = EdgeInsets.zero,
+    this.foregroundColor = Colors.white,
   });
 
   final ButtonType button;
@@ -30,11 +31,14 @@ class CalculatorButton extends StatelessWidget {
   /// 자식(글리프) 주변 패딩. 넓은 '0' 키의 글리프를 첫 칸 위로 좌측 정렬할 때 사용한다.
   final EdgeInsetsGeometry contentPadding;
 
+  /// 글리프 색. iOS 함수 키(AC/±/%)는 밝은 회색 배경에 검정 글리프를 쓴다.
+  final Color foregroundColor;
+
   @override
   Widget build(BuildContext context) {
     // 선택된 연산자는 배경/전경 색을 반전한다.
-    final backgroundColor = isSelected ? Colors.white : buttonColor;
-    final foregroundColor = isSelected ? buttonColor : Colors.white;
+    final background = isSelected ? Colors.white : buttonColor;
+    final foreground = isSelected ? buttonColor : foregroundColor;
 
     // 부모(SizedBox)가 정한 크기를 채운다. 넓은 버튼은 알약형(StadiumBorder).
     return ElevatedButton(
@@ -45,14 +49,14 @@ class CalculatorButton extends StatelessWidget {
         shape: wide ? const StadiumBorder() : const CircleBorder(),
         minimumSize: Size.zero,
         tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-        backgroundColor: backgroundColor,
-        disabledBackgroundColor: backgroundColor,
+        backgroundColor: background,
+        disabledBackgroundColor: background,
         elevation: 0,
         padding: contentPadding,
       ),
       child: switch (button) {
         .delete => Assets.svgs.delete.svg(
-          colorFilter: ColorFilter.mode(foregroundColor, BlendMode.srcIn),
+          colorFilter: ColorFilter.mode(foreground, BlendMode.srcIn),
           semanticsLabel: button.name,
           width: 40,
           height: 40,
@@ -60,7 +64,7 @@ class CalculatorButton extends StatelessWidget {
         _ => Text(
           button.text,
           style: TextStyle(
-            color: foregroundColor,
+            color: foreground,
             fontFamily: FontFamily.sFProDisplay,
             fontSize: button.text.length > 1 ? 23 : 36,
             fontWeight: FontWeight.w500,


### PR DESCRIPTION
## Description

Stacked on #82. Matches the keypad colors to the iOS calculator palette.

| Key | Before | After (iOS) |
|-----|--------|-------------|
| Digit | `#2B2B2D`, white glyph | `#333333`, white glyph |
| Function (AC / ± / %) | `#5C5C60`, white glyph | `#A5A5A5`, **black** glyph |
| Operator | `#FFA00A`, white glyph | `#FF9F0A`, white glyph |

The function keys needed a black glyph on the lighter background, so `CalculatorButton` gains a `foregroundColor` (default white); the three function keys pass black.

## Verification

- `flutter analyze` — no issues
- `flutter test` — 153/153 passing
- iPhone 17e simulator: function keys are light gray with black glyphs, digits and operators match iOS.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Test
